### PR TITLE
Fix "undefined function" bug when iterating an object created with Object.create(null)

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ function hasBinary(data) {
       }
 
       for (var key in obj) {
-        if (obj.hasOwnProperty(key) && _hasBinary(obj[key])) {
+        if (Object.prototype.hasOwnProperty.call(obj, key) && _hasBinary(obj[key])) {
           return true;
         }
       }


### PR DESCRIPTION
This fixes a bug for when the object is a plain object (created with `Object.create(null)`.

Consider [this](http://phrogz.net/death-to-hasownproperty) and [this](http://stackoverflow.com/questions/12017693/why-use-object-prototype-hasownproperty-callmyobj-prop-instead-of-myobj-hasow).

(Btw, this is breaking a whole socket.io codebase).
