### PR TITLE
fixed case where there is a Buffer but it does not has isBuffer defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function hasBinary(data) {
   function _hasBinary(obj) {
     if (!obj) return false;
 
-    if ( (global.Buffer && global.Buffer.isBuffer(obj)) ||
+    if ( (global.Buffer && global.Buffer.isBuffer && global.Buffer.isBuffer(obj)) ||
          (global.ArrayBuffer && obj instanceof ArrayBuffer) ||
          (global.Blob && obj instanceof Blob) ||
          (global.File && obj instanceof File)


### PR DESCRIPTION
Saw this issue while trying to use socket.io.js client. global.Buffer was present but isBuffer was not a function defined so the last part of the if would fail. I added a small check to make sure the function is present before calling.
