### PR TITLE
add repository information to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "dependencies": {
     "isarray": "0.0.1"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Automattic/has-binary/"
+  },
   "devDependencies": {
     "better-assert": "1.0.0",
     "mocha": "1.17.1"


### PR DESCRIPTION
creating a webjar (http://www.webjars.org/) is currently not possible due to missing repository information, so I added it
